### PR TITLE
fix version conflict with urllib caused by latest requests and latest botocore

### DIFF
--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __git_hash__ = "GIT_HASH"

--- a/requirements.pip
+++ b/requirements.pip
@@ -3,5 +3,5 @@
 boto>=2.48.0, <3
 botocore>=1.10.25, <2
 boto3>=1.4.7,<2
-requests>=2,<3
+requests==2.19.1
 typing>=3.6,<3.7


### PR DESCRIPTION
pin down version of requests to 2.19.1 b/c the latest version for requests, 2.20.0 brings in urllib 1.24 which causes a version conflict that the latest version of botocore 1.12.28, which requires urllib to be a version <1.24