### PR TITLE
Remove botocore from requirements

### DIFF
--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 __git_hash__ = "GIT_HASH"

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,6 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
 boto>=2.48.0, <3
-botocore>=1.10.25, <2
 boto3>=1.4.7,<2
 requests==2.19.1
 typing>=3.6,<3.7


### PR DESCRIPTION
This was pulling in a version of urllib that was conflicting with
requests, and it seems reasonable to just rely on the version of
botocore that boto and boto3 supply.