### PR TITLE
Changed requirement for requests package version

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -3,4 +3,4 @@
 boto>=2.48.0, <3
 boto3>=1.4.7,<2
 botostubs>=0.9.1.9.139,<1
-requests>=2.21.0,<3
+requests>=2.19.1,<3


### PR DESCRIPTION
There was a conflict betwen requests package versions used in vpc_killer
and amplify-aws-utils causing vpc_killer failure.

**pkg_resources.ContextualVersionConflict: (requests 2.19.1 (/j/jobs/aws-destroy-temp-vpcs/workspace/venv/lib/python3.6/site-packages), Requirement.parse('requests<3,>=2.21.0'), {'amplify-aws-utils'})**