### PR TITLE
BugFix: Don't Exit Early on Retrieving Paged Items

### DIFF
--- a/amplify_aws_utils/resource_helper.py
+++ b/amplify_aws_utils/resource_helper.py
@@ -204,8 +204,14 @@ def wait_for_sshable(remotecmd, instance, timeout=15 * 60, quiet=False):
         .format(instance, timeout))
 
 
-def get_boto3_paged_results(func: Callable, results_key: str, next_token_key: str = 'NextToken',
-                            next_request_token_key: str = 'NextToken', *args, **kwargs) -> List:
+def get_boto3_paged_results(
+        func: Callable,
+        results_key: str,
+        next_token_key: str = 'NextToken',
+        next_request_token_key: str = 'NextToken',
+        *args,
+        **kwargs
+) -> List:
     """
     Helper method for automatically making multiple boto3 requests for their listing functions
     :param func: Boto3 function to call
@@ -219,7 +225,7 @@ def get_boto3_paged_results(func: Callable, results_key: str, next_token_key: st
     if not response_items:
         logger.warning("No items found in response=%s", response)
 
-    while response.get(next_token_key) and response.get(results_key):
+    while response.get(next_token_key):
         kwargs[next_request_token_key] = response[next_token_key]
         response = throttled_call(func, *args, **kwargs)
         response_items += response[results_key]

--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Sometimes, the AWS API will return an empty array of items but will
still return a NextToken. This is expected behavior and we should
continue to iterate through the results.