### PR TITLE
Add STS Role Session Name Support

### DIFF
--- a/amplify_aws_utils/clients/sts.py
+++ b/amplify_aws_utils/clients/sts.py
@@ -1,5 +1,5 @@
 """Utilities for assuming AWS roles"""
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 import boto3
 import botostubs
@@ -10,19 +10,48 @@ class STS:
     def __init__(self, sts_client: botostubs.STS):
         self.sts_client = sts_client
 
-    def assume_role(self, account_id: str, role_name: str) -> Dict[str, str]:
-        """Return credentials of assumed role"""
+    def assume_role(
+            self,
+            account_id: str,
+            role_name: str,
+            role_session_name: Optional[str] = None
+    ) -> Dict[str, str]:
+        """
+        Assumes a role and returns its credentials.
+        :param account_id: The id of the account to assume the role in.
+        :param role_name: The name of the role to assume.
+        :param role_session_name: The name of the role session.
+        :return: A dictionary of the credentials.
+        """
         assumed_role_object = self.sts_client.assume_role(
             RoleArn='arn:aws:iam::%s:role/%s' % (account_id, role_name),
-            RoleSessionName='AssumedRole'
+            RoleSessionName=role_session_name or 'AssumedRole',
         )
 
         return assumed_role_object['Credentials']
 
-    def get_boto3_client_for_account(self, account_id: str, role_name: str, client_name: str, **kwargs) \
-            -> Any:
-        """Return a boto3 client instance using an assumed role for an account id"""
-        credentials = self.assume_role(account_id, role_name)
+    def get_boto3_client_for_account(
+            self,
+            account_id: str,
+            role_name: str,
+            client_name: str,
+            role_session_name: Optional[str] = None,
+            **kwargs
+    ) -> Any:
+        """
+        Convenience function for assuming a role into and then returning a boto3 client with that role.
+        :param account_id: The id of the account to assume the role in.
+        :param role_name: The name of the role to assume.
+        :param client_name: The name of the boto3 client to create.
+        :param role_session_name: The name of the role session.
+        :param kwargs: Any additional key word arguments to pass to the client's constructor.
+        :return: A boto3 client with credentials from the requested role.
+        """
+        credentials = self.assume_role(
+            account_id=account_id,
+            role_name=role_name,
+            role_session_name=role_session_name,
+        )
         return boto3.client(
             client_name,
             aws_access_key_id=credentials['AccessKeyId'],

--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.3.10"
+__version__ = "0.3.12"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_sts_helper.py
+++ b/test/unit/test_sts_helper.py
@@ -21,6 +21,15 @@ class TestSTSHelper(TestCase):
             RoleSessionName='AssumedRole'
         )
 
+    def test_assume_role_with_session_name(self):
+        """test getting credentials by assuming a role in a account with a session name"""
+        self.sts_helper.assume_role("1234", "fake-role", "fake-session-name")
+
+        self.sts_client.assume_role.assert_called_once_with(
+            RoleArn='arn:aws:iam::1234:role/fake-role',
+            RoleSessionName='fake-session-name',
+        )
+
     def test_get_boto3_client(self):
         """test getting a boto3 client with an assumed role"""
         self.sts_client.assume_role.return_value = {


### PR DESCRIPTION
Updated the STS helper to allow us to set the role session name when
assuming a role, to make it easier to track what exactly is using a
role.