### PR TITLE
AT-5032 Use GitHub Actions for Deploys

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -1,0 +1,65 @@
+name: Test and Optionally Publish
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+    test:
+        name: Check code against linter/unit tests
+        runs-on: ubuntu-18.04
+        strategy:
+          matrix:
+            python-version: [3.6, 3.7, 3.8, 3.9]
+        steps:
+        - uses: actions/checkout@master
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install dependencies
+          run: python -m pip install tox tox-gh-actions
+        - name: Test with Tox
+          run: tox
+
+    version-check:
+      name: Verify that version was updated
+      runs-on: ubuntu-18.04
+      if: github.ref != 'refs/heads/master'
+      steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Check version updated
+        run: bash bin/versionCheck.sh ${GITHUB_BASE_REF##*/} "true"
+
+    build-publish:
+        name: Build and publish Python distributions
+        runs-on: ubuntu-18.04
+        needs: [test]
+        if: github.ref == 'refs/heads/master'
+        steps:
+        - uses: actions/checkout@master
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.7
+        - name: Update GIT_HASH
+          run: sed --expression "s|GIT_HASH|$GITHUB_SHA|g" --in-place **/version.py
+        - name: Build tarball
+          run: python setup.py sdist
+        - name: Publish to Test PyPI
+          uses: pypa/gh-action-pypi-publish@master
+          with:
+            password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+            repository_url: https://test.pypi.org/legacy/
+            skip_existing: true
+        - name: Publish to PyPI
+          uses: pypa/gh-action-pypi-publish@master
+          with:
+            password: ${{ secrets.PYPI_API_TOKEN }}

--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.3.12"
+__version__ = "0.3.13"
 __git_hash__ = "GIT_HASH"

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -2,6 +2,10 @@
 pycodestyle
 pylint>=2.3.1,<3
 mypy
+types-boto>=0.1.2,<0.2
+types-mock>=0.1.3,<0.2
+types-requests>=2.25.2,<3
+types-six>=0.1.7,<0.2
 # Testing tools
 nose>=1.1,<2
 nose-cov>=1.5,<2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,13 @@
 [tox]
-envlist=lint,{py36}-unit,{py37}-unit,{py38}-unit
+envlist=lint,{py36,py37,py38,py39}-unit
 skipsdist=true
+
+[gh-actions]
+python =
+    3.6: py36-unit
+    3.7: py37-unit
+    3.8: py38-unit, lint
+    3.9: py39-unit
 
 [testenv]
 commands =
@@ -10,7 +17,7 @@ commands =
 
 [testenv:lint]
 whitelist_externals = npm
-basepython=python3.6
+basepython=python3.8
 commands =
     pip install --upgrade -r requirements.pip -r test-requirements.pip -e .
     pylint --rcfile=pylintrc --output-format=colorized amplify_aws_utils test bin


### PR DESCRIPTION
travis-ci no longer considers this to be an open source project, so migrate to GitHub Actions, which we already pay for.