### PR TITLE
decorator for handling uncaught exceptions in a lambda...

### DIFF
--- a/amplify_aws_utils/exceptions.py
+++ b/amplify_aws_utils/exceptions.py
@@ -17,3 +17,7 @@ class ExpectedTimeoutError(TimeoutError):
 
 class S3WritingError(RuntimeError):
     """S3 object is not written correctly"""
+
+
+class CatchAllExceptionError(RuntimeError):
+    """Error raised when handling catch all exceptions for an app/service"""

--- a/amplify_aws_utils/resource_helper.py
+++ b/amplify_aws_utils/resource_helper.py
@@ -2,14 +2,18 @@
 This module has utility functions for working with aws resources
 """
 import logging
-from typing import Dict, List, Sequence, Callable
+import traceback
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import boto3
+from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
+from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto.exception import EC2ResponseError, BotoServerError
 from botocore.exceptions import ClientError, WaiterError, ReadTimeoutError
 
 from amplify_aws_utils.jitter import Jitter
 from .exceptions import (
+    CatchAllExceptionError,
     TimeoutError,
     ExpectedTimeoutError,
     S3WritingError
@@ -366,3 +370,79 @@ def dynamodb_record_to_dict(record: Dict[str, Dict[str, str]]) -> Dict[str, str]
         key: list(value.values())[0]
         for key, value in record.items()
     }
+
+
+@lambda_handler_decorator
+def catchall_exception_lambda_handler_decorator(
+        handler: Callable,
+        event: Dict[str, Any],
+        context: LambdaContext,
+        log_exception: Optional[bool] = True,
+        raise_exception: Optional[bool] = True
+):
+    """
+    Decorator to handle uncaught exceptions for a lambda handler.
+
+    The lambda handler function being decorated must have the signature `handler(event, context)`.
+
+    This decorator will catch all uncaught exceptions from the decorated lambda handler function,
+    then manage it. There will be a particular focus on the exception chaining info of the
+    exception because by default it will be lost forever when the exception propagates out of the
+    lambda function. The exception can be handled as follows:
+
+        - optionally log the caught exception, including the exception chaining info, before the
+          exception propagates out of the lambda function.
+
+        - optionally raise new `CatchAllExceptionError` exception instance, with the error message
+          portion set with the caught exception's exception chaining info.
+
+    Note that setting both *log_exception* and *raise_exception* to True, the default, will
+    probably result in the exception being logged twice by your log service. It will first be
+    explicitly logged by this decorator when *log_exception* is True. Then, when *raise_exception*
+    is True, and the exception propagates out of the lambda function, your log service will
+    probably log it.
+
+    Example usage:
+
+        @catchall_exception_lambda_handler_decorator
+        def lambda_handler(event, context):
+            return True
+
+        @catchall_exception_lambda_handler_decorator(log_exception=False)
+        def lambda_handler(event, context):
+            return True
+
+        @catchall_exception_lambda_handler_decorator(raise_exception=False)
+        def lambda_handler(event, context):
+            return True
+
+        @catchall_exception_lambda_handler_decorator(log_exception=False, raise_exception=False)
+        def lambda_handler(event, context):
+            return True
+
+    :param handler: The lambda function's main handler
+    :param event: The incoming lambda event
+    :param context: The incoming lambda context
+    :param log_exception: Defaults to True. If True, will log the caught exception, including the
+    exception chaining.
+    :param raise_exception: Defaults to True. If True, will raise a new CatchAllExceptionError with
+    the error message portion set with the exception chaining info from the caught exception.
+    :return: The response of the lambda handler
+    """
+    try:
+        return handler(event, context)
+    except Exception as exc:
+        if log_exception:
+            # log stack trace info, including exception chaining
+            logger.exception("Catchall exception logging")
+
+        if raise_exception:
+            err_mssg = repr(exc)
+            stack_trace = traceback.format_exc()
+
+            # a bit kludgy to put the stack trace info into the error message portion of the
+            # exception, but necessary to retain the exception chaining info b/c exception
+            # chaining will be lost once an exception propagates out of a lambda function
+            raise CatchAllExceptionError(
+                f"Catchall exception. err_mssg: {err_mssg}, stack_trace: {stack_trace}"
+            ) from exc

--- a/amplify_aws_utils/resource_helper.py
+++ b/amplify_aws_utils/resource_helper.py
@@ -3,7 +3,7 @@ This module has utility functions for working with aws resources
 """
 import logging
 import traceback
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import boto3
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
@@ -372,6 +372,7 @@ def dynamodb_record_to_dict(record: Dict[str, Dict[str, str]]) -> Dict[str, str]
     }
 
 
+# pylint: disable=invalid-name
 @lambda_handler_decorator
 def catchall_exception_lambda_handler_decorator(
         handler: Callable,
@@ -379,7 +380,7 @@ def catchall_exception_lambda_handler_decorator(
         context: LambdaContext,
         log_exception: Optional[bool] = True,
         raise_exception: Optional[bool] = True
-):
+) -> Union[Dict[str, Any], None]:
     """
     Decorator to handle uncaught exceptions for a lambda handler.
 
@@ -446,3 +447,5 @@ def catchall_exception_lambda_handler_decorator(
             raise CatchAllExceptionError(
                 f"Catchall exception. err_mssg: {err_mssg}, stack_trace: {stack_trace}"
             ) from exc
+
+    return None

--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.3.17"
+__version__ = "0.3.18"
 __git_hash__ = "GIT_HASH"

--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.3.16"
+__version__ = "0.3.17"
 __git_hash__ = "GIT_HASH"

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,5 +1,6 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
+aws-lambda-powertools>=1.11.0,<2
 boto>=2.49.0, <3
 boto3>=1.19.0,<2
 botostubs>=0.14.1.18.64,<1

--- a/test/unit/test_resource_helper.py
+++ b/test/unit/test_resource_helper.py
@@ -9,21 +9,25 @@ from boto.exception import EC2ResponseError
 import boto.ec2.instance
 from botocore.exceptions import ClientError, WaiterError
 
-from amplify_aws_utils.exceptions import ExpectedTimeoutError
-from amplify_aws_utils.exceptions import TimeoutError
+from amplify_aws_utils.exceptions import (
+    CatchAllExceptionError,
+    ExpectedTimeoutError,
+    TimeoutError,
+)
 from amplify_aws_utils.resource_helper import (
     Jitter,
+    catchall_exception_lambda_handler_decorator,
+    dynamodb_record_to_dict,
     keep_trying,
     throttled_call,
+    wait_for_sshable,
     wait_for_state,
     wait_for_state_boto3,
-    wait_for_sshable,
-    dynamodb_record_to_dict,
 )
 
 
 # time.sleep is being patched but not referenced.
-# pylint: disable=W0613
+# pylint: disable=unused-argument
 class ResourceHelperTests(TestCase):
     """Test Resource Helper"""
 
@@ -245,3 +249,92 @@ class ResourceHelperTests(TestCase):
             expected,
             actual,
         )
+
+
+# aws_lambda_powertools.middleware_factory.factory.logger is being patched but not referenced.
+# pylint: disable=unused-argument
+class CatchallExceptionLambdaHandlerDecoratorTests(TestCase):
+
+    @patch("aws_lambda_powertools.middleware_factory.factory.logger")
+    @patch("amplify_aws_utils.resource_helper.logger")
+    def test_no_raise_exception(self, mock_logger, mock_aws_lambda_powertools_logger):
+        """Tests catchall_exception_lambda_handler_decorator, doesn't raise exception, does log exception"""
+        @catchall_exception_lambda_handler_decorator(raise_exception=False)
+        def _lambda_handler(*_):
+            raise MockError("some exception")
+
+        _lambda_handler({}, MagicMock)
+
+        mock_logger.exception.assert_called_once_with("Catchall exception logging")
+
+    @patch("aws_lambda_powertools.middleware_factory.factory.logger")
+    @patch("amplify_aws_utils.resource_helper.logger")
+    def test_no_log_exception(self, mock_logger, mock_aws_lambda_powertools_logger):
+        """Tests catchall_exception_lambda_handler_decorator, doesn't log exception, does raise exception"""
+        @catchall_exception_lambda_handler_decorator(log_exception=False)
+        def _lambda_handler(*_):
+            raise MockError("some exception")
+
+        with self.assertRaises(CatchAllExceptionError) as context:
+            _lambda_handler({}, MagicMock)
+
+        self.assertRegex(str(context.exception), "some exception")
+        mock_logger.exception.assert_not_called()
+
+    @patch("aws_lambda_powertools.middleware_factory.factory.logger")
+    @patch("amplify_aws_utils.resource_helper.logger")
+    def test_no_raise_no_log_exception(self, mock_logger, mock_aws_lambda_powertools_logger):
+        """Tests catchall_exception_lambda_handler_decorator, doesn't raise exception, doesn't log exception"""
+        @catchall_exception_lambda_handler_decorator(log_exception=False, raise_exception=False)
+        def _lambda_handler(*_):
+            raise MockError("some exception")
+
+        _lambda_handler({}, MagicMock)
+
+        mock_logger.exception.assert_not_called()
+
+    @patch("aws_lambda_powertools.middleware_factory.factory.logger")
+    @patch("amplify_aws_utils.resource_helper.logger")
+    def test_exception_chaining_in_err_mssg(self, mock_logger, mock_aws_lambda_powertools_logger):
+        """
+        Tests catchall_exception_lambda_handler_decorator correctly retains exception chaining
+        in exception error message
+        """
+        def _some_func():
+            raise RuntimeError("some exception 1")
+
+        @catchall_exception_lambda_handler_decorator
+        def _lambda_handler(*_):
+            try:
+                _some_func()
+            except Exception as exc:
+                raise RuntimeError("some exception 2") from exc
+
+        with self.assertRaises(CatchAllExceptionError) as context:
+            _lambda_handler({}, MagicMock)
+
+        self.assertRegex(str(context.exception), "some exception 1")
+        self.assertRegex(str(context.exception), "some exception 2")
+
+        mock_logger.exception.assert_called_once_with("Catchall exception logging")
+
+    @patch("amplify_aws_utils.resource_helper.logger")
+    def test_wrap_response(self, mock_logger):
+        """Tests catchall_exception_lambda_handler_decorator correctly wraps the response"""
+        mock_response = {
+            "foo": "bar",
+            1: 2,
+        }
+
+        @catchall_exception_lambda_handler_decorator
+        def _lambda_handler(*_):
+            return mock_response
+
+        actual = _lambda_handler({}, MagicMock())
+
+        self.assertEqual(
+            actual,
+            mock_response
+        )
+
+        mock_logger.exception.assert_not_called()


### PR DESCRIPTION
... focusing mostly on trying to retain exception chaining before the exception propagates out of the lambda function and exception chaining is lost forever.

this is a continuation of https://github.com/amplify-education/expeditor-api-v2/pull/233... and moving it to this package so that it's generic and can be used by all lambdas.