### PR TITLE
Add mypy_boto3_ssm to the requirements

### DIFF
--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __git_hash__ = "GIT_HASH"

--- a/requirements.pip
+++ b/requirements.pip
@@ -9,3 +9,4 @@ boto3-stubs[ec2]>=1.24.96,<2
 boto3-stubs[config]>=1.24.96,<2
 boto3-stubs[ssm]>=1.24.96,<2
 requests>=2.26.0,<3
+mypy_boto3_ssm>=1.26.77,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requirements.pip


### PR DESCRIPTION
Got this error from zookeeper

 ```
  File "/opt/wgen/bin/load_aws_services.py", line 30, in <module>
    from amplify_aws_utils.resource_helper import throttled_call, boto3_tags_to_dict, get_boto3_paged_results
  File "/usr/local/lib/python3.7/site-packages/amplify_aws_utils/resource_helper.py", line 14, in <module>
    from mypy_boto3_ssm.client import SSMClient
ModuleNotFoundError: No module named 'mypy_boto3_ssm'
```

https://github.com/amplify-education/amplify_aws_utils/blob/master/amplify_aws_utils/resource_helper.py#L14