### PR TITLE
Feat: upgrade ubuntu image to be latest for github actions

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     name: Check code against linter/unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
@@ -30,7 +30,7 @@ jobs:
 
   version-check:
     name: Verify that version was updated
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@master
@@ -41,7 +41,7 @@ jobs:
 
   build-publish:
     name: Build and publish Python distributions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [test]
     if: github.ref == 'refs/heads/master'
     steps:

--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     name: Check code against linter/unit tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
@@ -30,7 +30,7 @@ jobs:
 
   version-check:
     name: Verify that version was updated
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@master
@@ -41,7 +41,7 @@ jobs:
 
   build-publish:
     name: Build and publish Python distributions
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: [test]
     if: github.ref == 'refs/heads/master'
     steps:


### PR DESCRIPTION
Sounds like Github stopped [supporting the ubuntu-18.04 image](https://github.com/actions/runner-images/issues/6002) for their Github actions. The recommendation is to use the latest version or 20.04 or 22.04.