### PR TITLE
use python3.12 for publish action

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Update GIT_HASH
         run: sed --expression "s|GIT_HASH|$GITHUB_SHA|g" --in-place **/version.py
       - name: Build tarball


### PR DESCRIPTION
use python 3.12 for publish action so that it recognizes the classifiers in setup.py