### PR TITLE
Fix: Lower LogLevel for get_boto3_paged_results

### DIFF
--- a/amplify_aws_utils/resource_helper.py
+++ b/amplify_aws_utils/resource_helper.py
@@ -188,7 +188,7 @@ def get_boto3_paged_results(
     response = throttled_call(func, *args, **kwargs)
     response_items = response.get(results_key, [])
     if not response_items:
-        logger.warning("No items found in response=%s", response)
+        logger.debug("No items found in response=%s", response)
 
     next_token = response.get(next_token_key)
     prev_token = None

--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
This probably shouldn't have ever been a warning. Making it a debug
seems appropriate, as this is not actually a condition that
warrants investigation.