### PR TITLE
Feat: Consider DB Resuming A Throttle Exception

### DIFF
--- a/amplify_aws_utils/resource_helper.py
+++ b/amplify_aws_utils/resource_helper.py
@@ -108,6 +108,7 @@ def throttled_call(fun, *args, **kwargs):
                     "RequestLimitExceeded",
                     "TooManyRequestsException",
                     "ServiceUnavailable",
+                    "DatabaseResumingException",
                 )
             )
 

--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
This is basically an exception that says this resource isn't quite ready, please retry, so I think it's safe to treat it the same as the other throttling exceptions.