### PR TITLE
feat: add python3.14 support, drop python3.9/3.10 support

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     rev: v1.17.0    # Use the sha / tag you want to point at
     hooks:
       - id: mypy
-        args: [--python-version=3.9]
+        args: [--python-version=3.11]
         # You can use additional_dependencies to install types- packages
         # https://github.com/pre-commit/mirrors-mypy
         additional_dependencies:

--- a/amplify_aws_utils/version.py
+++ b/amplify_aws_utils/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 __git_hash__ = "GIT_HASH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 110
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.lint]
 # E/W: pycodestyle, F: pyflakes, I: import sorting (replaces isort).

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def get_requirements():
 
 setup(
     name="amplify_aws_utils",
-    python_requires=">=3.9.0",
+    python_requires=">=3.11.0",
     version=get_version(),
     description="Utility functions for working with AWS resources",
     long_description=get_long_description(),
@@ -54,8 +54,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,13 @@ VERSION_REGEX = re.compile(
     re.MULTILINE | re.VERBOSE,
 )
 
-VERSION_FILE = os.path.join("amplify_aws_utils", "version.py")
+THIS_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+VERSION_FILE = os.path.join(THIS_DIRECTORY, "amplify_aws_utils", "version.py")
 
 
 def get_long_description():
     """Reads the long description from the README"""
-    this_directory = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as file:
+    with open(os.path.join(THIS_DIRECTORY, "README.md"), encoding="utf-8") as file:
         return file.read()
 
 
@@ -38,7 +38,7 @@ def get_version():
 
 def get_requirements():
     """Reads the installation requirements from requirements.txt"""
-    with open("requirements.txt") as reqfile:
+    with open(os.path.join(THIS_DIRECTORY, "requirements.txt")) as reqfile:
         return [line for line in reqfile.read().split("\n") if not line.startswith(("#", "-"))]
 
 
@@ -59,6 +59,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     keywords="",
     author="Amplify Education",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py39}-unit,{py310}-unit,{py311}-unit,{py312}-unit,{py313}-unit,{py314}-unit
+envlist = {py311}-unit,{py312}-unit,{py313}-unit,{py314}-unit
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py39}-unit,{py310}-unit,{py311}-unit,{py312}-unit,{py313}-unit
+envlist = {py39}-unit,{py310}-unit,{py311}-unit,{py312}-unit,{py313}-unit,{py314}-unit
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
## Summary
- Add python3.14 support.
- Drop python3.9/3.10 support (raise the floor to python3.11), following the same bundling pattern as #73 (which added 3.13 and dropped 3.8 in one PR).

## Why (3.14 support)
Discovered while bumping `env_nap_time`'s Lambda runtime to python3.13/3.14 (its `amplify-aws-utils>=0.5,<0.6` install failed under a fresh python3.14 environment): `setup.py`'s `get_requirements()` and `VERSION_FILE` opened `requirements.txt`/`version.py` via bare relative paths, relying on the build's working directory matching the package root. That held under python3.13's build isolation but breaks under python3.14's -- a newer setuptools resolved into the isolated build environment no longer `chdir`s the same way, so the read fails with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```

Anchored both paths to `setup.py`'s own directory via `THIS_DIRECTORY = os.path.abspath(os.path.dirname(__file__))`, matching `get_long_description()`, which already did this correctly. This makes the build independent of the invoking process's cwd regardless of which setuptools version ends up resolved -- not just a python3.14-specific patch.

## Why (drop 3.9/3.10)
No compat-shim code in the package depended on <3.11 (checked; none found), so raising the floor is a pure metadata/tooling change with no code impact. Bundled into this PR rather than opening a second one, matching #73's precedent.

## Changes
- `setup.py`: `python_requires` `>=3.9.0` -> `>=3.11.0`; classifiers drop 3.9/3.10, add 3.14
- `tox.ini`: envlist drops `py39`/`py310`, adds `py314`
- `.github/workflows/test-build-publish.yml`: matrix drops `3.9`/`3.10`, adds `3.14`
- `.pre-commit-config.yaml`: mypy `--python-version` `3.9` -> `3.11`
- `pyproject.toml`: ruff `target-version` `py39` -> `py311`
- Version bump 0.6.2 -> 0.6.3 (patch, matching #73's precedent for a python-version-support bump)

## Test plan
- [x] `pip install .` succeeds under a real python3.14 interpreter (previously failed with the FileNotFoundError above)
- [x] Full test suite (58/58) passes under python3.14
- [x] `ruff check` / `ruff format --check` clean under the new `target-version`
- [x] Pre-commit hooks (trailing-whitespace, yamllint, mypy w/ `--python-version=3.11`, etc.) pass on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
